### PR TITLE
Code cleanup and handle bug in records with no timestamps

### DIFF
--- a/elastalert_modules/hour_range_enhancement.py
+++ b/elastalert_modules/hour_range_enhancement.py
@@ -7,7 +7,7 @@ class HourRangeEnhancement(BaseEnhancement):
 	def process(self, match):
 		timestamp = dateutil.parser.parse(match['timestamp']).time()
 		time_start = dateutil.parser.parse(self.rule['start_time']).time()
-                time_end = dateutil.parser.parse(self.rule['end_time']).time()
+		time_end = dateutil.parser.parse(self.rule['end_time']).time()
 		if(self.rule['drop_if'] == 'outside'):
 			if timestamp < time_start or timestamp > time_end:
 				raise DropMatchException()

--- a/elastalert_modules/hour_range_enhancement.py
+++ b/elastalert_modules/hour_range_enhancement.py
@@ -5,12 +5,13 @@ from elastalert.enhancements import DropMatchException
 
 class HourRangeEnhancement(BaseEnhancement):
 	def process(self, match):
-		timestamp = dateutil.parser.parse(match['timestamp']).time()
-		time_start = dateutil.parser.parse(self.rule['start_time']).time()
-		time_end = dateutil.parser.parse(self.rule['end_time']).time()
-		if(self.rule['drop_if'] == 'outside'):
-			if timestamp < time_start or timestamp > time_end:
-				raise DropMatchException()
-		elif(self.rule['drop_if'] == 'inside'):
-			if timestamp >= time_start and timestamp <= time_end:
-				raise DropMatchException()
+		if hasattr(match, 'timestamp'):
+			timestamp = dateutil.parser.parse(match['timestamp']).time()
+			time_start = dateutil.parser.parse(self.rule['start_time']).time()
+			time_end = dateutil.parser.parse(self.rule['end_time']).time()
+			if(self.rule['drop_if'] == 'outside'):
+				if timestamp < time_start or timestamp > time_end:
+					raise DropMatchException()
+			elif(self.rule['drop_if'] == 'inside'):
+				if timestamp >= time_start and timestamp <= time_end:
+					raise DropMatchException()


### PR DESCRIPTION
* commit de95f56 (HEAD -> master, origin/master, origin/HEAD)
| Author: Fmstrat <nospam@nowsci.com>
| Date:   2020-07-21 09:09:25
| 
|     Check for timestamp attribute before processing
|     
|     If a record in elasticsearch does not have a timestamp field, when the
|     module loads it fails with a missing key of timestamp. The hasattr
|     function eliminates this error, allowing records with no timestamp field
|     to pass through the module unmodified.
| 
| elastalert_modules/hour_range_enhancement.py
| 
* commit 6d3c30b
| Author: Fmstrat <nospam@nowsci.com>
| Date:   2020-07-21 09:09:37
| 
|     Synchronized tabs and spaces to support GUI editors
|     
|     As the time_end line used a combination of tabs and spaces, loading in a
|     GUI editor such as VSCode caused issues where time_end was indented
|     farther than it should be, causing python compilation errors.
| 
| elastalert_modules/hour_range_enhancement.py