### PR TITLE
Allow all character sets and @timestamp from ALK >= v7

### DIFF
--- a/elastalert_modules/hour_range_enhancement.py
+++ b/elastalert_modules/hour_range_enhancement.py
@@ -3,15 +3,23 @@ import dateutil.parser
 from elastalert.enhancements import BaseEnhancement
 from elastalert.enhancements import DropMatchException
 
+
 class HourRangeEnhancement(BaseEnhancement):
-	def process(self, match):
-		if hasattr(match, 'timestamp'):
-			timestamp = dateutil.parser.parse(match['timestamp']).time()
-			time_start = dateutil.parser.parse(self.rule['start_time']).time()
-			time_end = dateutil.parser.parse(self.rule['end_time']).time()
-			if(self.rule['drop_if'] == 'outside'):
-				if timestamp < time_start or timestamp > time_end:
-					raise DropMatchException()
-			elif(self.rule['drop_if'] == 'inside'):
-				if timestamp >= time_start and timestamp <= time_end:
-					raise DropMatchException()
+    def process(self, match):
+        timestamp = None
+        try:
+            timestamp = dateutil.parser.parse(match['@timestamp']).time()
+        except:
+            try:
+                timestamp = dateutil.parser.parse(match['timestamp']).time()
+            except:
+                pass
+        if timestamp != None:
+            time_start = dateutil.parser.parse(self.rule['start_time']).time()
+            time_end = dateutil.parser.parse(self.rule['end_time']).time()
+            if(self.rule['drop_if'] == 'outside'):
+                if timestamp < time_start or timestamp > time_end:
+                    raise DropMatchException()
+            elif(self.rule['drop_if'] == 'inside'):
+                if timestamp >= time_start and timestamp <= time_end:
+                    raise DropMatchException()


### PR DESCRIPTION
Elasticsearch now uses the @timestamp instead of timestamp variable so
it should be leveraged when possible. Also, the `hasattr` function
appears to be both inefficient (and ineffectual at UTF8) so most
developers recommend using a try/except. This has been rectified as
well.