### PR TITLE
Get the timestamp_field property name according to the documentation

### DIFF
--- a/elastalert_modules/hour_range_enhancement.py
+++ b/elastalert_modules/hour_range_enhancement.py
@@ -11,7 +11,7 @@ class HourRangeEnhancement(BaseEnhancement):
             timestamp = dateutil.parser.parse(match['@timestamp']).time()
         except Exception:
             try:
-                timestamp = dateutil.parser.parse(match['timestamp']).time()
+                timestamp = dateutil.parser.parse(match[self.rule['timestamp_field']]).time()
             except Exception:
                 pass
         if timestamp is not None:


### PR DESCRIPTION
my timestamp is property was not @timestamp nor timestamp, and I've see that in the documentation : 

All documents must have a timestamp field. ElastAlert will try to use **@timestamp** by default, but this can be changed with the timestamp_field option. By default, ElastAlert uses ISO8601 timestamps, though unix timestamps are supported by setting timestamp_type.

So I submit this PR to allow to use any timestamp field using this enhancement !